### PR TITLE
[PTCD-333, PTCD-334] Fix default radius and town mapping

### DIFF
--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/DASHelper.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/DASHelper.cs
@@ -16,8 +16,8 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
     public class DASHelper : IDASHelper
     {
         // TODO: Add to config
-        private const double NationalLat = 52.264858;
-        private const double NationalLon = -1.466888;
+        private const double NationalLat = 52.564269;
+        private const double NationalLon = -1.466056;
         private readonly IReferenceDataServiceClient _referenceDataServiceClient;
 
         private readonly TelemetryClient _telemetryClient;
@@ -119,14 +119,14 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
         }
 
         public List<DasStandard> ApprenticeshipsToStandards(int exportKey, IEnumerable<Apprenticeship> apprenticeships,
-            Dictionary<string, ApprenticeshipLocation> uniqueProviderLocations)
+            Dictionary<string, ApprenticeshipLocation> validLocations)
         {
             var standards = new List<DasStandard>();
             foreach (var apprenticeship in apprenticeships)
             {
                 if (!apprenticeship.StandardCode.HasValue) continue;
                 var apprenticeshipLocations =
-                    LinkApprenticeshipLocationsToProvider(uniqueProviderLocations, apprenticeship);
+                    LinkApprenticeshipLocationsToProvider(validLocations, apprenticeship);
 
                 standards.Add(new DasStandard
                 {
@@ -148,7 +148,7 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
 
         public List<DasFramework> ApprenticeshipsToFrameworks(int exportKey,
             IEnumerable<Apprenticeship> apprenticeships,
-            Dictionary<string, ApprenticeshipLocation> uniqueProviderLocations)
+            Dictionary<string, ApprenticeshipLocation> validLocations)
         {
             var frameworks = new List<DasFramework>();
 
@@ -157,7 +157,7 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
                 if (!apprenticeship.FrameworkCode.HasValue) continue;
 
                 var apprenticeshipLocations =
-                    LinkApprenticeshipLocationsToProvider(uniqueProviderLocations, apprenticeship);
+                    LinkApprenticeshipLocationsToProvider(validLocations, apprenticeship);
 
                 frameworks.Add(new DasFramework
                 {
@@ -205,7 +205,7 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
                         {
                             Id = int.Parse(regionIndex),
                             DeliveryModes = ConvertToApprenticeshipDeliveryModes(currentLocation),
-                            Radius = currentLocation.Radius ?? 0
+                            Radius = currentLocation.Radius ?? 50 // TODO: Add to config
                         });
                     }
                 }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/DASHelper.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/DASHelper.cs
@@ -215,7 +215,7 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
                     var isNational = currentLocation.National != null && currentLocation.National.Value;
                     var radius = isNational
                         ? 500 // National
-                        : currentLocation.Radius ?? 0;
+                        : currentLocation.Radius ?? 10;
 
                     locationRefs.Add(new DasLocationRef
                     {

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/DASHelper.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/DASHelper.cs
@@ -96,7 +96,8 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
                                 County = currentLocation.Address?.County,
                                 Lat = currentLocation.Address?.Latitude,
                                 Long = currentLocation.Address?.Longitude,
-                                Postcode = currentLocation.Address?.Postcode
+                                Postcode = currentLocation.Address?.Postcode,
+                                Town = currentLocation.Address?.Town
                             },
                             Name = currentLocation.Name,
                             Email = currentLocation.Address?.Email,


### PR DESCRIPTION
[PTCD-333] Fix default radius when reported as null
Due to a tidy up with Apprenticeship data fore QA, some locations are reported with a null radius. This changes sets the following default values:
- REGIONS = 50 miles
- VENUES = 10 miles
This is in-line with the original hardcoded values

[PTCD-334] Fixed missing town mapping
The town field has not been mapped correctly since the initial release. This is a small fix to add town to the export.

[PTCD-333]: https://skillsfundingagency.atlassian.net/browse/PTCD-333
[PTCD-334]: https://skillsfundingagency.atlassian.net/browse/PTCD-334