### PR TITLE
Generate export by schedule

### DIFF
--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Functions/GetApprenticeshipsAsProviderTests.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Functions/GetApprenticeshipsAsProviderTests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Dfc.Providerportal.FindAnApprenticeship.Functions;
+using Dfc.Providerportal.FindAnApprenticeship.Models;
+using Dfc.Providerportal.FindAnApprenticeship.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Dfc.ProviderPortal.FindAnApprenticeship.UnitTests.Functions
+{
+    public class GetApprenticeshipsAsProviderTests
+    {
+        private readonly Mock<IBlobStorageClient> _blobStorageClient;
+        private readonly Mock<Func<DateTimeOffset>> _nowUtc;
+        private readonly GetApprenticeshipsAsProvider _function;
+
+        public GetApprenticeshipsAsProviderTests()
+        {
+            _blobStorageClient = new Mock<IBlobStorageClient>();
+            _nowUtc = new Mock<Func<DateTimeOffset>>();
+            _function = new GetApprenticeshipsAsProvider(_blobStorageClient.Object, _nowUtc.Object);
+        }
+
+        [Fact]
+        public async Task Run_WithExportAvailableForToday_ReturnsTodaysExport()
+        {
+            var now = DateTimeOffset.UtcNow.Date;
+            _nowUtc.Setup(s => s.Invoke())
+                .Returns(now);
+
+            var todaysBlob = "{\"id\":\"TodaysBlob\"}";
+            var todaysExportKey = new ExportKey(now);
+
+            var todaysBlobClient = new Mock<BlobClient>();
+            todaysBlobClient.Setup(s => s.DownloadAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ReturnBlob(todaysBlob));
+
+            _blobStorageClient.Setup(s => s.GetBlobClient(It.Is<string>(blobName => blobName == todaysExportKey)))
+                .Returns(todaysBlobClient.Object);
+
+            var yesterdaysBlob = "{\"id\":\"YesterdaysBlob\"}";
+            var yesterdayExportKey = new ExportKey(now.AddDays(-1));
+
+            var yesterdaysBlobClient = new Mock<BlobClient>();
+            yesterdaysBlobClient.Setup(s => s.DownloadAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ReturnBlob(yesterdaysBlob));
+
+            _blobStorageClient.Setup(s => s.GetBlobClient(It.Is<string>(blobName => blobName == yesterdayExportKey)))
+                .Returns(yesterdaysBlobClient.Object);
+
+            var result = await _function.Run(new Mock<HttpRequest>().Object, NullLogger.Instance, CancellationToken.None) as FileStreamResult;
+
+            result.Should().NotBeNull();
+            result.ContentType.Should().Be("application/json");
+
+            using var sr = new StreamReader(result.FileStream);
+            var contentResult = await sr.ReadToEndAsync();
+
+            contentResult.Should().Be(todaysBlob);
+        }
+
+        [Fact]
+        public async Task Run_WithNoExportAvailableForTodayAndExportAvailableForYesterday_ReturnsYesterdaysExport()
+        {
+            var now = DateTimeOffset.UtcNow;
+            _nowUtc.Setup(s => s.Invoke())
+                .Returns(now);
+
+            var todaysExportKey = new ExportKey(now);
+
+            var todaysBlobClient = new Mock<BlobClient>();
+            todaysBlobClient.Setup(s => s.DownloadAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(StatusCodes.Status404NotFound, "Not Found"));
+
+            _blobStorageClient.Setup(s => s.GetBlobClient(It.Is<string>(blobName => blobName == todaysExportKey)))
+                .Returns(todaysBlobClient.Object);
+
+            var yesterdaysBlob = "{\"id\":\"YesterdaysBlob\"}";
+            var yesterdayExportKey = new ExportKey(now.AddDays(-1));
+
+            var yesterdaysBlobClient = new Mock<BlobClient>();
+            yesterdaysBlobClient.Setup(s => s.DownloadAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ReturnBlob(yesterdaysBlob));
+
+            _blobStorageClient.Setup(s => s.GetBlobClient(It.Is<string>(blobName => blobName == yesterdayExportKey)))
+                .Returns(yesterdaysBlobClient.Object);
+
+            var result = await _function.Run(new Mock<HttpRequest>().Object, NullLogger.Instance, CancellationToken.None) as FileStreamResult;
+
+            result.Should().NotBeNull();
+            result.ContentType.Should().Be("application/json");
+
+            using var sr = new StreamReader(result.FileStream);
+            var contentResult = await sr.ReadToEndAsync();
+
+            contentResult.Should().Be(yesterdaysBlob);
+        }
+
+        [Fact]
+        public async Task Run_WithNoExportAvailableForTodayOrYesterday_ReturnsNotFound()
+        {
+            var now = DateTimeOffset.UtcNow;
+            _nowUtc.Setup(s => s.Invoke())
+                .Returns(now);
+
+            var blobClient = new Mock<BlobClient>();
+            blobClient.Setup(s => s.DownloadAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(StatusCodes.Status404NotFound, "Not Found"));
+
+            _blobStorageClient.Setup(s => s.GetBlobClient(It.IsAny<string>()))
+                .Returns(blobClient.Object);
+
+            var result = await _function.Run(new Mock<HttpRequest>().Object, NullLogger.Instance, CancellationToken.None) as NotFoundResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        }
+
+        private static Func<Response<BlobDownloadInfo>> ReturnBlob(string blobContent) => () =>
+        {
+            var response = new Mock<Response<BlobDownloadInfo>>();
+
+            response.SetupGet(s => s.Value)
+                .Returns(BlobsModelFactory.BlobDownloadInfo(content: new MemoryStream(Encoding.UTF8.GetBytes(blobContent))));
+
+            return response.Object;
+        };
+    }
+}

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Helper/DasHelperTests.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Helper/DasHelperTests.cs
@@ -2,12 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using Dfc.Providerportal.FindAnApprenticeship.Helper;
-using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Helper;
 using Dfc.Providerportal.FindAnApprenticeship.Models;
 using Dfc.Providerportal.FindAnApprenticeship.Models.Enums;
 using Dfc.Providerportal.FindAnApprenticeship.Models.Providers;
 using Microsoft.ApplicationInsights;
-using Moq;
 using Xunit;
 
 namespace Dfc.ProviderPortal.FindAnApprenticeship.UnitTests.Helper
@@ -18,13 +16,11 @@ namespace Dfc.ProviderPortal.FindAnApprenticeship.UnitTests.Helper
         {
             private readonly DASHelper _dasHelper;
             private readonly TelemetryClient _telemetryClient;
-            private readonly Mock<IReferenceDataServiceClient> _referenceDataServiceClient;
 
             public DasHelperFixture()
             {
                 var _telemetryClient = new TelemetryClient();
-                _referenceDataServiceClient = new Mock<IReferenceDataServiceClient>();
-                _dasHelper = new DASHelper(_telemetryClient, _referenceDataServiceClient.Object);
+                _dasHelper = new DASHelper(_telemetryClient);
             }
 
             public DASHelper Sut => _dasHelper;
@@ -74,13 +70,13 @@ namespace Dfc.ProviderPortal.FindAnApprenticeship.UnitTests.Helper
             {
                 // Arrange
                 var contactDetails = provider.ProviderContact.FirstOrDefault();
-                var expected = 
-                    !string.IsNullOrWhiteSpace(contactDetails.ContactTelephone1) 
-                        ? contactDetails.ContactTelephone1 
+                var expected =
+                    !string.IsNullOrWhiteSpace(contactDetails.ContactTelephone1)
+                        ? contactDetails.ContactTelephone1
                         : contactDetails.ContactTelephone2;
 
                 // Act
-                var result = _sut.CreateDasProviderFromProvider(123, provider);
+                var result = _sut.CreateDasProviderFromProvider(123, provider, null);
                 var actual = result.Phone;
 
                 // Assert

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Integration/GetApprenticeshipsAsProviderIntegrationTests.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Integration/GetApprenticeshipsAsProviderIntegrationTests.cs
@@ -71,7 +71,7 @@ namespace Dfc.ProviderPortal.FindAnApprenticeship.UnitTests.Integration
             _providerServiceClient = new ProviderServiceClient(_providerService);
             
             _DASHelper = new DASHelper(_telemetryClient, _referenceDataServiceClient);
-            _apprenticeshipService = new ApprenticeshipService(_telemetryClient, _cosmosDbHelper.Object, _cosmosSettings, _providerServiceClient, _DASHelper, _appCache);
+            _apprenticeshipService = new ApprenticeshipService(_cosmosDbHelper.Object, _cosmosSettings, _DASHelper, _providerServiceClient, _telemetryClient);
 
             _generateProviderExportFunction = new GenerateProviderExportFunction(_apprenticeshipService, _blobStorageClient.Object);
             _getApprenticeshipAsProviderFunction = new GetApprenticeshipsAsProvider(_blobStorageClient.Object, _nowUtc.Object);

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Integration/GetApprenticeshipsAsProviderIntegrationTests.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Integration/GetApprenticeshipsAsProviderIntegrationTests.cs
@@ -68,7 +68,7 @@ namespace Dfc.ProviderPortal.FindAnApprenticeship.UnitTests.Integration
             _referenceDataServiceClient = new ReferenceDataServiceClient(_telemetryClient, new Mock<IOptions<ReferenceDataServiceSettings>>().Object, _appCache, _referenceDataService);
             _providerResponse = new Mock<Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>();
             _providerService = new ProviderService(new HttpClient(new MockHttpMessageHandler(_providerResponse.Object)) { BaseAddress = new Uri("https://test.com") });
-            _providerServiceClient = new ProviderServiceClient(new Mock<IOptions<ProviderServiceSettings>>().Object, _appCache, _providerService);
+            _providerServiceClient = new ProviderServiceClient(_providerService);
             
             _DASHelper = new DASHelper(_telemetryClient, _referenceDataServiceClient);
             _apprenticeshipService = new ApprenticeshipService(_telemetryClient, _cosmosDbHelper.Object, _cosmosSettings, _providerServiceClient, _DASHelper, _appCache);

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Integration/GetApprenticeshipsAsProviderIntegrationTests.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship.unittests/Integration/GetApprenticeshipsAsProviderIntegrationTests.cs
@@ -103,8 +103,8 @@ namespace Dfc.ProviderPortal.FindAnApprenticeship.UnitTests.Integration
             _blobStorageClient.Setup(s => s.GetBlobClient(It.Is<string>(blobName => blobName == new ExportKey(now))))
                 .Returns(blobClient.Object);
 
-            blobClient.Setup(s => s.UploadAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
-                .Callback<Stream, CancellationToken>((s, ct) =>
+            blobClient.Setup(s => s.UploadAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Callback<Stream, bool, CancellationToken>((s, o, ct) =>
                 {
                     using (var ms = new MemoryStream())
                     {

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Dfc.Providerportal.FindAnApprenticeship.csproj
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Dfc.Providerportal.FindAnApprenticeship.csproj
@@ -9,8 +9,6 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.4.4" />
     <PackageReference Include="Dfc.ProviderPortal.Packages" Version="0.1.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
-    <PackageReference Include="LazyCache" Version="2.0.4" />
-    <PackageReference Include="LazyCache.AspNetCore" Version="2.0.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GenerateProviderExportFunction.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GenerateProviderExportFunction.cs
@@ -37,25 +37,29 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Functions
             string export = null;
             try
             {
+                var generateStopwatch = Stopwatch.StartNew();
+
                 var apprenticeships = (List<Apprenticeship>)await _apprenticeshipService.GetLiveApprenticeships();
 
                 export = JsonConvert.SerializeObject(
                     (await _apprenticeshipService.ApprenticeshipsToDasProviders(apprenticeships)).Where(r => r.Success).Select(r => r.Result),
                     new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 
-                log.LogInformation($"Completed generation of {{{nameof(exportKey)}}}.", exportKey);
+                generateStopwatch.Stop();
+
+                log.LogInformation($"Completed generation of {{{nameof(exportKey)}}} in {generateStopwatch.Elapsed}.", exportKey);
             }
             catch (Exception ex)
             {
                 log.LogError(ex, $"Failed to generate {{{nameof(exportKey)}}}.", exportKey);
+                return;
             }
 
             try
             {
                 log.LogInformation($"Started upload of {{{nameof(exportKey)}}}.", exportKey);
 
-                var uploadStopwatch = new Stopwatch();
-                uploadStopwatch.Start();
+                var uploadStopwatch = Stopwatch.StartNew();
 
                 var blobClient = _blobStorageClient.GetBlobClient(exportKey);
 

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GenerateProviderExportFunction.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GenerateProviderExportFunction.cs
@@ -40,7 +40,7 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Functions
                 var apprenticeships = (List<Apprenticeship>)await _apprenticeshipService.GetLiveApprenticeships();
 
                 export = JsonConvert.SerializeObject(
-                    _apprenticeshipService.ApprenticeshipsToDasProviders(apprenticeships).Where(r => r.Success).Select(r => r.Result),
+                    (await _apprenticeshipService.ApprenticeshipsToDasProviders(apprenticeships)).Where(r => r.Success).Select(r => r.Result),
                     new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 
                 log.LogInformation($"Completed generation of {{{nameof(exportKey)}}}.", exportKey);

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GenerateProviderExportFunction.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GenerateProviderExportFunction.cs
@@ -61,7 +61,7 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Functions
 
                 using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(export)))
                 {
-                    await blobClient.UploadAsync(stream, ct);
+                    await blobClient.UploadAsync(stream, true, ct);
                 }
 
                 uploadStopwatch.Stop();

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GenerateProviderExportFunction.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GenerateProviderExportFunction.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Services;
+using Dfc.Providerportal.FindAnApprenticeship.Models;
+using Dfc.Providerportal.FindAnApprenticeship.Storage;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Dfc.Providerportal.FindAnApprenticeship.Functions
+{
+    public class GenerateProviderExportFunction
+    {
+        private readonly IApprenticeshipService _apprenticeshipService;
+        private readonly IBlobStorageClient _blobStorageClient;
+
+        public GenerateProviderExportFunction(IApprenticeshipService apprenticeshipService, IBlobStorageClient blobStorageClient)
+        {
+            _apprenticeshipService = apprenticeshipService ?? throw new ArgumentNullException(nameof(apprenticeshipService));
+            _blobStorageClient = blobStorageClient ?? throw new ArgumentNullException(nameof(blobStorageClient));
+        }
+
+        [FunctionName("GenerateProviderExport")]
+        public async Task Run([TimerTrigger("%GenerateProviderExportSchedule%")]TimerInfo timer, ILogger log, CancellationToken ct)
+        {
+            var exportKey = ExportKey.FromUtcNow();
+
+            log.LogInformation($"Started generation of {{{nameof(exportKey)}}}.", exportKey);
+
+            string export = null;
+            try
+            {
+                var apprenticeships = (List<Apprenticeship>)await _apprenticeshipService.GetLiveApprenticeships();
+
+                export = JsonConvert.SerializeObject(
+                    _apprenticeshipService.ApprenticeshipsToDasProviders(apprenticeships).Where(r => r.Success).Select(r => r.Result),
+                    new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+
+                log.LogInformation($"Completed generation of {{{nameof(exportKey)}}}.", exportKey);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, $"Failed to generate {{{nameof(exportKey)}}}.", exportKey);
+            }
+
+            try
+            {
+                log.LogInformation($"Started upload of {{{nameof(exportKey)}}}.", exportKey);
+
+                var uploadStopwatch = new Stopwatch();
+                uploadStopwatch.Start();
+
+                var blobClient = _blobStorageClient.GetBlobClient(exportKey);
+
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(export)))
+                {
+                    await blobClient.UploadAsync(stream, ct);
+                }
+
+                uploadStopwatch.Stop();
+
+                log.LogInformation($"Completed upload of {{{nameof(exportKey)}}} in {uploadStopwatch.Elapsed}.", exportKey);
+            }
+            catch (Exception ex)
+            {
+                log.LogWarning(ex, $"Failed to upload {{{nameof(exportKey)}}}.", exportKey);
+            }
+        }
+    }
+}

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GetApprenticeshipsAsProviderByUkprn.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Functions/GetApprenticeshipsAsProviderByUkprn.cs
@@ -48,7 +48,7 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Functions
                     return new NotFoundObjectResult(ErrorResult($"No apprentiships found for UKPRN {ukprn}."));
                 }
                     
-                var result = _apprenticeshipService.ApprenticeshipsToDasProviders(apprenticeships).Single();
+                var result = (await _apprenticeshipService.ApprenticeshipsToDasProviders(apprenticeships)).Single();
 
                 return new OkObjectResult(DasProviderResultViewModel.FromDasProviderResult(result));
             }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/DASHelper.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/DASHelper.cs
@@ -20,21 +20,18 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
         // TODO: Add to config
         private const double NationalLat = 52.564269;
         private const double NationalLon = -1.466056;
-        private readonly IReferenceDataServiceClient _referenceDataServiceClient;
         private readonly TelemetryClient _telemetryClient;
 
-        public DASHelper(TelemetryClient telemetryClient, IReferenceDataServiceClient referenceDataServiceClient)
+        public DASHelper(TelemetryClient telemetryClient)
         {
             Throw.IfNull(telemetryClient, nameof(telemetryClient));
-            Throw.IfNull(referenceDataServiceClient, nameof(referenceDataServiceClient));
 
             _telemetryClient = telemetryClient;
-            _referenceDataServiceClient = referenceDataServiceClient;
         }
 
         [Obsolete("Please don't use this any more, instead replace with a mapper class using something like AutoMapper",
             false)]
-        public DasProvider CreateDasProviderFromProvider(int exportKey, Provider provider)
+        public DasProvider CreateDasProviderFromProvider(int exportKey, Provider provider, FeChoice feChoice)
         {
             if (!int.TryParse(provider.UnitedKingdomProviderReferenceNumber, out var ukprn))
                 throw new InvalidUkprnException(provider.UnitedKingdomProviderReferenceNumber);
@@ -44,9 +41,6 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
             try
             {
                 var contactDetails = provider.ProviderContact.FirstOrDefault();
-
-                var feChoice = _referenceDataServiceClient
-                    .GetFeChoicesByUKPRN(provider.UnitedKingdomProviderReferenceNumber);
 
                 return new DasProvider
                 {

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/ProviderService.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/ProviderService.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Services;
@@ -18,25 +16,14 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
             _httpClient = httpClient;
         }
 
-        public IEnumerable<Provider> GetActiveProviders()
-        {
-            return GetActiveProvidersAsync().GetAwaiter().GetResult();
-        }
-
         public async Task<IEnumerable<Provider>> GetActiveProvidersAsync()
         {
-            Console.WriteLine($"[{DateTime.UtcNow:G}] Cache missing or expired... Refreshing Active Providers cache");
-
             var response = await _httpClient.GetAsync($"GetActiveProviders");
 
             response.EnsureSuccessStatusCode();
 
-            var json = await response.Content.ReadAsStringAsync();
-            List<Provider> providers = JsonConvert.DeserializeObject<IEnumerable<Provider>>(json).ToList();
-
-            Console.WriteLine($"[{DateTime.UtcNow:G}] Loaded {providers.Count} active Providers to cache");
-
-            return providers;
+            return JsonConvert.DeserializeObject<IEnumerable<Provider>>(
+                await response.Content.ReadAsStringAsync());
         }
     }
 }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/ReferenceDataService.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/ReferenceDataService.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Services;
@@ -18,26 +16,14 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
             _httpClient = httpClient;
         }
 
-        public IEnumerable<FeChoice> GetAllFeChoices()
-        {
-            return GetAllFeChoicesAsync().GetAwaiter().GetResult();
-        }
-
         public async Task<IEnumerable<FeChoice>> GetAllFeChoicesAsync()
         {
-            Console.WriteLine($"[{DateTime.UtcNow:G}] Cache missing or expired... Refreshing FeChoices cache");
-
             // TODO: Request config changes from devops to remove 'FeChoices' from the base URL
             var response = await _httpClient.GetAsync("");
 
             response.EnsureSuccessStatusCode();
 
-            var json = await response.Content.ReadAsStringAsync();
-            List<FeChoice> feChoices = JsonConvert.DeserializeObject<IEnumerable<FeChoice>>(json).ToList();
-
-            Console.WriteLine($"[{DateTime.UtcNow:G}] Loaded {feChoices.Count} FE Choices to cache");
-
-            return feChoices;
+            return JsonConvert.DeserializeObject<IEnumerable<FeChoice>>(await response.Content.ReadAsStringAsync());
         }
     }
 }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/ReferenceDataServiceClient.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Helper/ReferenceDataServiceClient.cs
@@ -1,17 +1,10 @@
-﻿using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Helper;
-using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Settings;
-using Dfc.Providerportal.FindAnApprenticeship.Models;
-using Dfc.Providerportal.FindAnApprenticeship.Settings;
-using Dfc.ProviderPortal.Packages;
-using Microsoft.Extensions.Options;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
+using System.Threading.Tasks;
+using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Helper;
 using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Services;
-using LazyCache;
-using Microsoft.ApplicationInsights;
+using Dfc.Providerportal.FindAnApprenticeship.Models;
 
 namespace Dfc.Providerportal.FindAnApprenticeship.Helper
 {
@@ -19,46 +12,17 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Helper
     public class ReferenceDataServiceClient : IReferenceDataServiceClient
     {
         private readonly IReferenceDataService _service;
-        private readonly IAppCache _cache;
-        private readonly TelemetryClient _telemetryClient;
-        private readonly IReferenceDataServiceSettings _settings;
-        public ReferenceDataServiceClient(
-            TelemetryClient telemetryClient, 
-            IOptions<ReferenceDataServiceSettings> settings, 
-            IAppCache cache,
-            IReferenceDataService service)
-        {
-            Throw.IfNull(telemetryClient, nameof(telemetryClient));
-            Throw.IfNull(settings, nameof(settings));
-            Throw.IfNull(cache, nameof(cache));
-            Throw.IfNull(service, nameof(service));
 
-            _telemetryClient = telemetryClient;
-            _settings = settings.Value;
-            _cache = cache;
-            _service = service;
+        public ReferenceDataServiceClient(IReferenceDataService service)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
         }
 
-        public FeChoice GetFeChoicesByUKPRN(string UKPRN)
+        public async Task<IEnumerable<FeChoice>> GetAllFeChoiceData()
         {
             try
             {
-                var validUkprn = int.Parse(UKPRN);
-                return this.GetAllFeChoiceData().SingleOrDefault(x => x.UKPRN == validUkprn);
-            }
-            catch (Exception e)
-            {
-                throw new ReferenceDataServiceException(UKPRN, e);
-            }
-        }
-
-        public IEnumerable<FeChoice> GetAllFeChoiceData()
-        {
-            Func<IEnumerable<FeChoice>> feChoicesGetter = () => _service.GetAllFeChoices();
-
-            try
-            {
-                return _cache.GetOrAdd("FeChoices", feChoicesGetter, DateTimeOffset.Now.AddHours(8));
+                return await _service.GetAllFeChoicesAsync();
             }
             catch (HttpRequestException e)
             {

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Helper/IDASHelper.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Helper/IDASHelper.cs
@@ -1,15 +1,15 @@
 ﻿using System;
-using Dfc.Providerportal.FindAnApprenticeship.Models;
-using Dfc.Providerportal.FindAnApprenticeship.Models.Providers;
-using Dfc.Providerportal.FindAnApprenticeship.Models.DAS;
 using System.Collections.Generic;
+using Dfc.Providerportal.FindAnApprenticeship.Models;
+using Dfc.Providerportal.FindAnApprenticeship.Models.DAS;
+using Dfc.Providerportal.FindAnApprenticeship.Models.Providers;
 
 namespace Dfc.Providerportal.FindAnApprenticeship.Interfaces.Helper
 {
     [Obsolete("Please try not to use this any more, and instead create Mapper classes using Automapper or similar", false)]
     public interface IDASHelper
     {
-        DasProvider CreateDasProviderFromProvider(int exportKey, Provider provider);
+        DasProvider CreateDasProviderFromProvider(int exportKey, Provider provider, FeChoice feChoice);
         List<DasLocation> ApprenticeshipLocationsToLocations(int exportKey, Dictionary<string, ApprenticeshipLocation> locations);
         List<DasStandard> ApprenticeshipsToStandards(int exportKey, IEnumerable<Apprenticeship> apprenticeships,
             Dictionary<string, ApprenticeshipLocation> validLocations);

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Helper/IProviderServiceClient.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Helper/IProviderServiceClient.cs
@@ -1,12 +1,11 @@
-﻿using Dfc.Providerportal.FindAnApprenticeship.Models.Providers;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dfc.Providerportal.FindAnApprenticeship.Models.Providers;
 
 namespace Dfc.Providerportal.FindAnApprenticeship.Interfaces.Helper
 {
     public interface IProviderServiceClient
     {
-        IEnumerable<Provider> GetAllProviders();
-
-        IEnumerable<Provider> GetProviderByUkprn(int ukprn);
+        Task<IEnumerable<Provider>> GetAllProviders();
     }
 }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Helper/IReferenceDataServiceClient.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Helper/IReferenceDataServiceClient.cs
@@ -1,14 +1,11 @@
-﻿using Dfc.Providerportal.FindAnApprenticeship.Models;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dfc.Providerportal.FindAnApprenticeship.Models;
 
 namespace Dfc.Providerportal.FindAnApprenticeship.Interfaces.Helper
 {
     public interface IReferenceDataServiceClient
     {
-        IEnumerable<FeChoice> GetAllFeChoiceData();
-
-        FeChoice GetFeChoicesByUKPRN(string UKPRN);
+        Task<IEnumerable<FeChoice>> GetAllFeChoiceData();
     }
 }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Services/IApprenticeshipService.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Services/IApprenticeshipService.cs
@@ -11,6 +11,6 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Interfaces.Services
         Task<IEnumerable<IApprenticeship>> GetApprenticeshipCollection();
         Task<IEnumerable<IApprenticeship>> GetLiveApprenticeships();
         Task<IEnumerable<IApprenticeship>> GetApprenticeshipsByUkprn(int ukprn);
-        IEnumerable<DasProviderResult> ApprenticeshipsToDasProviders(List<Apprenticeship> apprenticeships);
+        Task<IEnumerable<DasProviderResult>> ApprenticeshipsToDasProviders(List<Apprenticeship> apprenticeships);
     }
 }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Services/IProviderService.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Services/IProviderService.cs
@@ -6,7 +6,6 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Interfaces.Services
 {
     public interface IProviderService
     {
-        IEnumerable<Provider> GetActiveProviders();
         Task<IEnumerable<Provider>> GetActiveProvidersAsync();
     }
 }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Services/IReferenceDataService.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Interfaces/Services/IReferenceDataService.cs
@@ -6,7 +6,6 @@ namespace Dfc.Providerportal.FindAnApprenticeship.Interfaces.Services
 {
     public interface IReferenceDataService
     {
-        IEnumerable<FeChoice> GetAllFeChoices();
         Task<IEnumerable<FeChoice>> GetAllFeChoicesAsync();
     }
 }

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Models/ExportKey.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Models/ExportKey.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Dfc.Providerportal.FindAnApprenticeship.Models
+{
+    public class ExportKey
+    {
+        private readonly DateTimeOffset _keyDateTime;
+
+        public ExportKey(DateTimeOffset keyDateTime)
+        {
+            _keyDateTime = keyDateTime.Date;
+        }
+
+        public static ExportKey FromUtcNow()
+        {
+            return new ExportKey(DateTimeOffset.UtcNow);
+        }
+
+        public override string ToString()
+        {
+            return $"providers-{_keyDateTime:yyyyMMdd}.json";
+        }
+
+        public static implicit operator string(ExportKey exportKey)
+        {
+            return exportKey?.ToString();
+        }
+    }
+}

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Startup.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Startup.cs
@@ -5,9 +5,10 @@ using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Helper;
 using Dfc.Providerportal.FindAnApprenticeship.Interfaces.Services;
 using Dfc.Providerportal.FindAnApprenticeship.Services;
 using Dfc.Providerportal.FindAnApprenticeship.Settings;
+using Dfc.Providerportal.FindAnApprenticeship.Storage;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 
 [assembly: FunctionsStartup(typeof(Startup))]
 namespace Dfc.Providerportal.FindAnApprenticeship
@@ -68,6 +69,13 @@ namespace Dfc.Providerportal.FindAnApprenticeship
 
             services.AddSingleton<IReferenceDataServiceClient, ReferenceDataServiceClient>();
             services.AddSingleton<IProviderServiceClient, ProviderServiceClient>();
+            services.AddSingleton<Func<DateTimeOffset>>(() => DateTimeOffset.UtcNow);
+            services.AddSingleton<IBlobStorageClient>(s =>
+                new AzureBlobStorageClient(
+                    new AzureBlobStorageClientOptions(
+                        s.GetRequiredService<IConfiguration>().GetValue<string>("AzureWebJobsStorage"),
+                        "fatp-providersexport")));
+
             services.AddScoped<ICosmosDbHelper, CosmosDbHelper>();
             services.AddScoped<IDASHelper, DASHelper>();
             services.AddScoped<IApprenticeshipService, ApprenticeshipService>();

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Startup.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Startup.cs
@@ -28,8 +28,6 @@ namespace Dfc.Providerportal.FindAnApprenticeship
                 .AddEnvironmentVariables()
                 .Build();
 
-            services.AddLazyCache();
-
             #region Settings & Config
             
             var cosmosDbSettings = configuration.GetSection(nameof(CosmosDbSettings));

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Storage/AzureBlobStorageClient.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Storage/AzureBlobStorageClient.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+namespace Dfc.Providerportal.FindAnApprenticeship.Storage
+{
+    public class AzureBlobStorageClient : IBlobStorageClient
+    {
+        private readonly BlobContainerClient _blobContainerClient;
+
+        public AzureBlobStorageClient(AzureBlobStorageClientOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _blobContainerClient = new BlobContainerClient(options.ConnectionString, options.BlobContainerName);
+            _blobContainerClient.CreateIfNotExists(PublicAccessType.None);
+        }
+
+        public BlobClient GetBlobClient(string blobName)
+        {
+            if (string.IsNullOrWhiteSpace(blobName))
+            {
+                throw new ArgumentNullException(nameof(blobName));
+            }
+
+            return _blobContainerClient.GetBlobClient(blobName);
+        }
+    }
+}

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Storage/AzureBlobStorageClientOptions.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Storage/AzureBlobStorageClientOptions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Dfc.Providerportal.FindAnApprenticeship.Storage
+{
+    public class AzureBlobStorageClientOptions
+    {
+        public string ConnectionString { get; }
+
+        public string BlobContainerName { get; }
+
+        public AzureBlobStorageClientOptions(string connectionString, string blobContainerName)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            if (string.IsNullOrWhiteSpace(blobContainerName))
+            {
+                throw new ArgumentNullException(nameof(blobContainerName));
+            }
+
+            ConnectionString = connectionString;
+            BlobContainerName = blobContainerName;
+        }
+    }
+}

--- a/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Storage/IBlobStorageClient.cs
+++ b/dfc.providerportal.findanapprenticeship/src/dfc.providerportal.findanapprenticeship/Storage/IBlobStorageClient.cs
@@ -1,0 +1,9 @@
+﻿using Azure.Storage.Blobs;
+
+namespace Dfc.Providerportal.FindAnApprenticeship.Storage
+{
+    public interface IBlobStorageClient
+    {
+        BlobClient GetBlobClient(string blobName);
+    }
+}


### PR DESCRIPTION
Possible story:

As a *Consumer of the FATP bulk providers API*
I want the Export of the API endpoint to be automatically generated by a schedule
so that a consistent response is returned by the API endpoint and I have a record of what has been returned without having to wait for it to be generated on request

Acceptance Criteria
* WHEN I configure the schedule to run at a given time (midnight UTC) THEN the Export generation is executed at that time (midnight UTC)
* WHEN the Export genertion is triggerd by the schedule THEN the results of that Export are generated using live data
* WHEN the Export genertion is triggerd by the schedule THEN the results of that Export are recorded in blob storage
* WHEN I call the FATP bulk api endpoint at bulk/providers THEN an Export is returned for that day from blob storage
* WHEN I call the FATP bulk api endpoint at bulk/providers AND there is no output generated for that day THEN yesterdays Export is returned
* WHEN I call the FATP bulk api endpoint at bulk/providers AND there is no output generated for that day or yesterday THEN an error response is returned